### PR TITLE
Fix filter usage

### DIFF
--- a/src/main/groovy/com/ullink/gradle/opencover/OpenCover.groovy
+++ b/src/main/groovy/com/ullink/gradle/opencover/OpenCover.groovy
@@ -67,10 +67,10 @@ class OpenCover extends ConventionTask {
         def commandLineArgs = [openCoverConsole, '-register:user', '-mergebyhash']
         if (returnTargetCode) commandLineArgs += '-returntargetcode'
         if (mergeOutput) commandLineArgs += '-mergeoutput'
+
         commandLineArgs += ["-target:${getTargetExec()}", "\"-targetargs:${getTargetExecArgs().collect({escapeArg(it)}).join(' ')}\"", "-targetdir:${project.buildDir}"]
-        getTargetAssemblies().each {
-            commandLineArgs += "+[${FilenameUtils.getBaseName(project.file(it).name)}]"
-        }
+        def filters = getTargetAssemblies().collect { "+[${FilenameUtils.getBaseName(project.file(it).name)}]*" }
+        commandLineArgs += '-filter:"' + filters.join(' ') + '"'
         commandLineArgs += "-output:${getCoverageReportPath()}"
     }
 


### PR DESCRIPTION
Previously there was no actual filtering done, as the assembly names
were not valid filters and were not specified with the proper "filter"
parameter

Moreoever, newer versions of OpenCover were not supported, because
of commit
https://github.com/sawilde/opencover/commit/95495b76e1f8f06d8128f46dbaa2152d68a9cb93

This commit will also _greatly_ improve the size of the generated
coverage reports by including only target assemblies.
