### PR TITLE
Do not use relocated commons-io artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # gradle-opencover-plugin changelog
 
+## 1.6
+### Fixed
+* Do not use relocated artifact for commons-io
+
 ## 1.5
 ### Added
 * OpenCover register mode can be set via the `registerMode` parameter according to opencover's [usage](https://github.com/OpenCover/opencover/wiki/Usage). Can be (set to) `null` to disable the parameter

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'nu.studer.plugindev'
 apply plugin: 'net.researchgate.release'
 
 dependencies {
-    compile 'org.apache.commons:commons-io:1.3.2'
+    compile 'commons-io:commons-io:1.3.2'
 }
 
 group = 'com.ullink.gradle'


### PR DESCRIPTION
This artifact was relocated but Gradle has a problem with relocated
artifacts in transitive dependencies (both artifacts end up in the
classpath). By using directly the right group id we can avoid this
problem.

See issues:
- https://issues.sonatype.org/browse/MVNCENTRAL-244
- https://issues.gradle.org/browse/GRADLE-3301
