### PR TITLE
Remove merge command for parallel runs

### DIFF
--- a/src/main/groovy/com/ullink/gradle/opencover/OpenCover.groovy
+++ b/src/main/groovy/com/ullink/gradle/opencover/OpenCover.groovy
@@ -32,8 +32,9 @@ class OpenCover extends ConventionTask {
         inputs.files {
             getTargetAssemblies()
         }
-        outputs.files {
-           getReportsFolder().listFiles()
+
+        outputs.dir {
+           getReportsFolder()
         }
     }
 

--- a/src/main/groovy/com/ullink/gradle/opencover/OpenCover.groovy
+++ b/src/main/groovy/com/ullink/gradle/opencover/OpenCover.groovy
@@ -7,8 +7,6 @@ import org.gradle.api.internal.ConventionTask
 import groovyx.gpars.GParsPool
 import org.gradle.api.tasks.TaskAction
 
-import java.nio.file.Paths
-
 class OpenCover extends ConventionTask {
     def openCoverHome
     def openCoverVersion
@@ -21,8 +19,7 @@ class OpenCover extends ConventionTask {
     def excludeByFile
     def excludeByAttribute
     def hideSkipped
-    def reportGeneratorVersion
-    def assemblyFilters
+    def coverageReportPath
 
     boolean returnTargetCode = true
     boolean ignoreFailures = false
@@ -36,7 +33,7 @@ class OpenCover extends ConventionTask {
             getTargetAssemblies()
         }
         outputs.files {
-            getCoverageReportPath()
+           getReportsFolder().listFiles()
         }
     }
 
@@ -56,17 +53,6 @@ class OpenCover extends ConventionTask {
         openCoverExec
     }
 
-    def getReportGeneratorConsole() {
-        assert getReportGeneratorHome(), "You must install ReportGenerator to merge intermediate results"
-        File reportGeneratorExec = new File(getReportGeneratorHome().toString(), "ReportGenerator.exe")
-        reportGeneratorExec
-    }
-
-    def getReportGeneratorHome() {
-        def reportGenerator = 'reportgenerator-' + reportGeneratorVersion
-        Paths.get(project.gradle.gradleUserHomeDir.toString(), 'caches', 'reportgenerator', reportGenerator)
-    }
-
     def getOutputFolder() {
         new File(project.buildDir, 'opencover')
     }
@@ -76,7 +62,7 @@ class OpenCover extends ConventionTask {
     }
 
     def getCoverageReportPath() {
-        new File(reportsFolder, 'coverage.xml')
+        coverageReportPath
     }
 
     @TaskAction
@@ -91,9 +77,11 @@ class OpenCover extends ConventionTask {
         def commandLineArgs = getCommonOpenCoverArgs()
 
         if (!getParallelForks() || getParallelTargetExecArgs().size() == 0) {
+            coverageReportPath = new File(reportsFolder, "coverage.xml")
             runSingleOpenCover(commandLineArgs)
         }
         else {
+            coverageReportPath = reportsFolder.path.toString() + File.separator + "*.xml"
             runMultipleOpenCovers(commandLineArgs)
         }
     }
@@ -125,25 +113,17 @@ class OpenCover extends ConventionTask {
     }
 
     def runMultipleOpenCovers(ArrayList commandLineArgs) {
-        def intermediateReportsPath = new File(reportsFolder, "intermediate-results-" + name)
-        intermediateReportsPath.mkdirs()
-
         GParsPool.withPool {
             getParallelTargetExecArgs().eachParallel {
                 def fileName = getRandomFileName()
                 logger.info("Filename generated for the ${it} input was ${fileName}")
 
                 commandLineArgs += ["\"-targetargs:${it.collect({escapeArg(it)}).join(' ')}\""]
-                commandLineArgs += "-output:${new File(intermediateReportsPath, fileName + ".xml")}"
+                commandLineArgs += "-output:${new File(reportsFolder, fileName + ".xml")}"
 
                 execute(commandLineArgs)
             }
         }
-
-        execute(getMergeCommand(intermediateReportsPath))
-
-        new File(reportsFolder, "Summary.xml").renameTo(new File(reportsFolder, "coverage.xml"))
-        intermediateReportsPath.deleteDir()
     }
 
     def getRandomFileName() {
@@ -169,15 +149,5 @@ class OpenCover extends ConventionTask {
         if (!ignoreFailures && mbr.exitValue < 0) {
             throw new GradleException("${openCoverConsole} execution failed (ret=${mbr.exitValue})");
         }
-    }
-
-    def getMergeCommand(File intermediateReportsPath) {
-        def mergeCommand = [getReportGeneratorConsole()]
-        mergeCommand += "\"-reports:${intermediateReportsPath}\\*.xml\""
-        mergeCommand += "\"-targetdir: ${reportsFolder}\""
-        mergeCommand += "-assemblyfilters:+${getAssemblyFilters()}"
-        mergeCommand += "-reporttypes:xmlSummary"
-
-        mergeCommand
     }
 }

--- a/src/main/groovy/com/ullink/gradle/opencover/OpenCoverNUnitPlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/opencover/OpenCoverNUnitPlugin.groovy
@@ -4,7 +4,6 @@ import com.ullink.gradle.nunit.NUnitTestResultsMerger
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import com.ullink.gradle.*
 
 class OpenCoverNUnitPlugin implements Plugin<Project> {
     void apply(Project project) {

--- a/src/main/groovy/com/ullink/gradle/opencover/OpenCoverPlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/opencover/OpenCoverPlugin.groovy
@@ -24,11 +24,6 @@ class OpenCoverPlugin implements Plugin<Project> {
             downloadOpenCover(project, version)
         }
 
-        task.conventionMapping.map 'reportGeneratorVersion', {'2.5.11.0'}
-        if (task.parallelForks) {
-            downloadReportGenerator(project, task.getReportGeneratorVersion())
-        }
-
         if (project.plugins.hasPlugin('msbuild')) {
             task.dependsOn project.tasks.msbuild
             task.conventionMapping.map "targetAssemblies", {
@@ -61,38 +56,10 @@ class OpenCoverPlugin implements Plugin<Project> {
         ret
     }
 
-    File downloadReportGenerator(Project project, String version){
-        def dest = new File(new File(project.gradle.gradleUserHomeDir, 'caches'), 'reportgenerator')
-
-        if (!dest.exists()) {
-            dest.mkdirs()
-        }
-
-        def ret = new File(dest, "reportgenerator-${version}")
-        if (!ret.exists()) {
-            project.logger.info "Downloading & Unpacking Report Generator - version ${version}"
-
-            def tmpFile = File.createTempFile("reportgenerator.zip", null)
-
-            new URL(getReportGeneratorUrl(version)).withInputStream { i ->
-                tmpFile.withOutputStream {
-                    it << i
-                }
-            }
-            project.ant.unzip(src: tmpFile, dest: ret)
-        }
-        ret
-    }
-
     def getOpenCoverUrl(def version) {
         if (version <= '4.5.3207') {
             return "https://bitbucket.org/shaunwilde/opencover/downloads/opencover.${version}.zip"
         }
         return "https://github.com/OpenCover/opencover/releases/download/${version}/opencover.${version}.zip"
-    }
-
-    def getReportGeneratorUrl(def version)
-    {
-        return "https://github.com/danielpalme/ReportGenerator/releases/download/v${version}/ReportGenerator_${version}.zip"
     }
 }


### PR DESCRIPTION
- the generated merged report file done by
Report Generator is not recognized by sonar
- instead the list of intermediate files will
be provided to sonar by setting the proper path
in coverageReportPath
- for single run there should be no impact

Change-Id: I760026db26520c1324f7430f521239ed4b49b4c3