### PR TITLE
Update ref. to fix download of nunit console > 3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'net.researchgate.release'
 dependencies {
     compile 'commons-io:commons-io:1.3.2'
     compile 'org.codehaus.gpars:gpars:1.2.1'
-    compile 'com.ullink.gradle:gradle-nunit-plugin:1.9'
+    compile 'com.ullink.gradle:gradle-nunit-plugin:1.12'
 }
 
 group = 'com.ullink.gradle'


### PR DESCRIPTION
Download is done by the gradle-nunit-plugin
and nunit runner was moved to a separate project since 3.5