### PR TITLE
Fix issue with parallel opencover execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle/
 build/
 .idea/
+*.iml
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
When runnning more tests than the number of threads in the thread pool, the test arguments are appended to the previous ones, making opencover crash with "Invalid outputfile" exception for tests started in the second batch.
Also simplified result file name generation, new file names are IDs. This has been done for clarity and also to reduce the change of PathTooLongException.