### PR TITLE
Make fileNameId static

### DIFF
--- a/src/main/groovy/com/ullink/gradle/opencover/OpenCover.groovy
+++ b/src/main/groovy/com/ullink/gradle/opencover/OpenCover.groovy
@@ -27,7 +27,7 @@ class OpenCover extends ConventionTask {
     boolean mergeOutput = false
     boolean skipAutoProps = false
 
-    def fileNameId = new AtomicLong(1)
+    static def fileNameId = new AtomicLong(1)
 
     OpenCover() {
         conventionMapping.map 'registerMode', { 'user' }


### PR DESCRIPTION
In case of more opencover tasks are defined.